### PR TITLE
Failed get or server error now reports http error code and description.

### DIFF
--- a/pyotp/pyotp.py
+++ b/pyotp/pyotp.py
@@ -147,6 +147,9 @@ def route(
 
     r = requests.get(url, params=query)
     
+    #check for request error
+    r.raise_for_status()
+
     #if error then return emptly GeoDataFrame
     if 'error' in r.json():
         return gpd.GeoDataFrame()


### PR DESCRIPTION
Previous behaviour reported a json error for http errors. When users see, for example, an Internal Server Error, they know to check the server logs.

Previous output from server error: 

    JSONDecodeError: Expecting value: line 1 column 1 (char 0)

New output:

    HTTPError: 500 Server Error: Internal Server Error for url: http://localhost:8080/otp/routers/default/plan?fromPlace=...